### PR TITLE
Update to work with agda-stdlib-2.0

### DIFF
--- a/src/Ataca/Core.agda
+++ b/src/Ataca/Core.agda
@@ -158,22 +158,21 @@ private
 
   instance
     monadTac : Monad (Tac {ℓ})
-    monadTac .return = done
-    monadTac ._>>=_  = bindTac
+    monadTac = mkMonad _ done bindTac
 
     functorTac : Functor (Tac {ℓ})
     functorTac = Monad.rawFunctor it
 
     applicativeTac : Applicative (Tac {ℓ})
-    applicativeTac = Monad.rawIApplicative it
+    applicativeTac = Monad.rawApplicative it
 
     applicativeZeroTac : ApplicativeZero (Tac {ℓ})
-    applicativeZeroTac .ApplicativeZero.applicative = it
-    applicativeZeroTac .empty = failTac
+    applicativeZeroTac .ApplicativeZero.rawApplicative = it
+    applicativeZeroTac .ApplicativeZero.rawEmpty .Empty.empty = failTac
 
     alternativeTac : Alternative (Tac {ℓ})
-    alternativeTac .Alternative.applicativeZero = it
-    alternativeTac ._<|>_ = chooseTac
+    alternativeTac .Alternative.rawApplicativeZero = it
+    alternativeTac .Alternative.rawChoice .Choice._<|>_ = chooseTac
 
     functorLiftTac : FunctorLift Tac ℓ A
     functorLiftTac .liftF  = liftFTac

--- a/src/Ataca/Core.agda
+++ b/src/Ataca/Core.agda
@@ -113,7 +113,7 @@ private
   liftTC' : TC (Tac A) → TC A → Tac A
   liftTC' err m = goalTac λ goal → (_, goal) $
     step $ TC.catchTC
-      (done <$> foldl (flip TC.extendContext) m (map snd $ goal .goalCtx))
+      (done <$> foldl (flip (uncurry TC.extendContext)) m (goal .goalCtx))
       err
 
   -- Run TC action, backtracking on failure

--- a/src/Ataca/Tactics/BasicTactics.agda
+++ b/src/Ataca/Tactics/BasicTactics.agda
@@ -38,7 +38,7 @@ module _ where
   unquoteTac u = liftTC! $ TC.unquoteTC u
 
   getContext : Tac Telescope
-  getContext = map ("x" ,_) <$> liftTC! TC.getContext
+  getContext = liftTC! TC.getContext
 
   freshName : String → Tac Name
   freshName n = liftTC! $ TC.freshName n

--- a/src/Ataca/Utils.agda
+++ b/src/Ataca/Utils.agda
@@ -14,7 +14,7 @@ open import Data.Nat.Base public using (ℕ; zero; suc) hiding (module ℕ)
 module ℕ where
   open import Data.Nat.Base public
   open import Data.Nat.Show public
-open import Data.Product public using (Σ; _×_; _,_; _,′_) renaming (proj₁ to fst; proj₂ to snd; map₁ to first; map₂ to second)
+open import Data.Product public using (Σ; _×_; _,_; _,′_; curry; uncurry) renaming (proj₁ to fst; proj₂ to snd; map₁ to first; map₂ to second)
 open import Data.String.Base public using (String)
 module String = Data.String.Base
 open import Data.Sum.Base public using (_⊎_) renaming (inj₁ to left; inj₂ to right)
@@ -122,7 +122,7 @@ makeImplicit (arg (arg-info v r) x) = arg (arg-info hidden r) x
 
 extendCtxTel : Telescope → TC A → TC A
 extendCtxTel []              = id
-extendCtxTel ((_ , a) ∷ tel) = TC.extendContext a ∘ extendCtxTel tel
+extendCtxTel ((x , a) ∷ tel) = TC.extendContext x a ∘ extendCtxTel tel
 
 goalErr : Term → TC (List TC.ErrorPart)
 goalErr goal = do
@@ -141,7 +141,7 @@ piView = λ where
 {-# TERMINATING #-}
 telePi : Type → TC (Telescope × Type)
 telePi t = piView t >>= λ where
-  (just (a , (abs x b))) → first ((x , a) ∷_) <$> TC.extendContext a (telePi b)
+  (just (a , (abs x b))) → first ((x , a) ∷_) <$> TC.extendContext x a (telePi b)
   nothing → return ([] , t)
 
 getArgInfo : Arg A → ArgInfo

--- a/src/Ataca/Utils.agda
+++ b/src/Ataca/Utils.agda
@@ -28,29 +28,31 @@ open import Level public using (Level; Setω; 0ℓ; _⊔_; Lift; lift; lower) re
 
 open import Relation.Binary.PropositionalEquality using (_≡_; refl) public
 
-open import Reflection.Term public
-open import Reflection.Name public using (Name)
-open import Reflection.Definition public hiding (_≟_)
-open import Reflection.Abstraction public using (Abs; abs; unAbs)
-open import Reflection.Argument public using (Arg; arg; vArg; hArg; unArg)
-open import Reflection.Argument.Modality using (Modality) public
-open import Reflection.Argument.Visibility using (Visibility; visible; instance′; hidden) public
-open import Reflection.Argument.Relevance using (Relevance; relevant; irrelevant) public
-open import Reflection.Argument.Information public using (ArgInfo; arg-info; visibility; modality)
+open import Reflection.AST.Term public
+open import Reflection.AST.Name public using (Name)
+open import Reflection.AST.Definition public hiding (_≟_)
+open import Reflection.AST.Abstraction public using (Abs; abs; unAbs)
+open import Reflection.AST.Argument public using (Arg; arg; vArg; hArg; unArg)
+open import Reflection.AST.Argument.Modality using (Modality) public
+open import Reflection.AST.Argument.Visibility using (Visibility; visible; instance′; hidden) public
+open import Reflection.AST.Argument.Relevance using (Relevance; relevant; irrelevant) public
+open import Reflection.AST.Argument.Information public using (ArgInfo; arg-info; visibility; modality)
 
-open import Data.List.Instances public hiding (listMonadT)
-open import Data.Maybe.Instances public hiding (maybeMonadT)
-open import Reflection.TypeChecking.Monad.Instances public
+open import Data.List.Instances public -- hiding (listMonadT)
+open import Data.Maybe.Instances public -- hiding (maybeMonadT)
+open import Reflection.TCM.Instances public
 
-open import Reflection.TypeChecking.Monad public using (ErrorPart; strErr; termErr)
+open import Reflection.TCM public using (ErrorPart; strErr; termErr)
 
-open import Category.Functor public using () renaming (RawFunctor to Functor)
-open import Category.Applicative public using ()
+open import Effect.Empty public using () renaming (RawEmpty to Empty)
+open import Effect.Choice public using () renaming (RawChoice to Choice)
+open import Effect.Functor public using () renaming (RawFunctor to Functor)
+open import Effect.Applicative public using ()
   renaming ( RawApplicative to Applicative
            ; RawApplicativeZero to ApplicativeZero
            ; RawAlternative to Alternative
            )
-open import Category.Monad public using () renaming ( RawMonad to Monad )
+open import Effect.Monad public using () renaming ( RawMonad to Monad ; mkRawMonad to mkMonad)
 open Functor         {{...}} public using (_<$>_; _<$_)
 open Applicative     {{...}} public using (pure) renaming (_⊛_ to _<*>_)
 open ApplicativeZero {{...}} public using () renaming (∅ to empty)
@@ -77,7 +79,7 @@ void m = const _ <$> m
 
 choice1 : {{Alternative F}} → List (F A) → F A
 choice1 []       = empty
-  where instance applicativeZeroF = Alternative.applicativeZero it
+  where instance applicativeZeroF = Alternative.rawApplicativeZero it
 choice1 (f ∷ []) = f
 choice1 (f ∷ fs) = f <|> choice1 fs
 
@@ -110,7 +112,7 @@ open FunctorLift {{...}} public
 -- Reflection stuff
 
 module TC where
-  open import Reflection.TypeChecking.Monad public
+  open import Reflection.TCM public
   newMeta! = newMeta unknown
 
 TC = TC.TC
@@ -155,5 +157,5 @@ piArgInfos t = teleArgInfos ∘ fst <$> telePi t
 
 instance
   functorLiftTC : FunctorLift TC ℓ A
-  functorLiftTC .liftF   = λ mx → TC.bindTC mx (λ x → TC.return (lift x))
-  functorLiftTC .lowerF  = λ mx → TC.bindTC mx (λ x → TC.return (lower x))
+  functorLiftTC .liftF   = λ mx → TC.bindTC mx (λ x → TC.pure (lift x))
+  functorLiftTC .lowerF  = λ mx → TC.bindTC mx (λ x → TC.pure (lower x))


### PR DESCRIPTION
This builds on top of #2

The main changes are:
- Reflection.{Term,Name,Definition,Argument} -> Reflection.AST.{...}
- TypeChecking.Monad -> TCM
- Category.* -> Effect.*
- Category.\*.foo -> Category.\*.rawFoo
- Other minor changes in Reflection and TCM API